### PR TITLE
Fix compilation with latest nCine version

### DIFF
--- a/api_c++/jugimapNCINE/jmNCine.cpp
+++ b/api_c++/jugimapNCINE/jmNCine.cpp
@@ -379,7 +379,7 @@ void DeleteNCNode(ncine::SceneNode* _node)
 {
 
     if(deleteNCNodesSpecial){
-        nctl::List<ncine::SceneNode *>children = _node->children();     // Children list as copy (not reference)!
+        nctl::Array<ncine::SceneNode *>children = _node->children();     // Children array as copy (not reference)!
         for(ncine::SceneNode* child : children){
             DeleteNCNode(child);
         }

--- a/examples_c++/ApiDemoTest/ApiDemoTest_nCine/main.cpp
+++ b/examples_c++/ApiDemoTest/ApiDemoTest_nCine/main.cpp
@@ -89,7 +89,7 @@ void MyEventHandler::onFrameStart()
 
 
 
-//#ifdef __ANDROID__
+#ifdef __ANDROID__
 void MyEventHandler::onTouchDown(const ncine::TouchEvent &event)
 {
     apiTestDemo::mouse.SetPressed(true);
@@ -107,7 +107,7 @@ void MyEventHandler::onTouchMove(const ncine::TouchEvent &event)
 {
     apiTestDemo::mouse.SetScreenPosition(jugimap::Vec2f(event.pointers[0].x, event.pointers[0].y));
 }
-//#endif
+#endif
 
 
 


### PR DESCRIPTION
- The `children()` method of a `SceneNode` now returns a `nctl::Array`
- Remove comment delimiters around touch input methods